### PR TITLE
:fire: Remove Img2B64 project

### DIFF
--- a/TRX2HTML Solution/TRX2HTML Solution.sln
+++ b/TRX2HTML Solution/TRX2HTML Solution.sln
@@ -34,8 +34,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "html", "html", "{6744114E-A
 		html\template.htm = html\template.htm
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Img2B64", "Img2B64\Img2B64.csproj", "{76C5961A-21CC-4CB0-9840-1553F96DF77A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,13 +73,6 @@ Global
 		{EF8684C1-83B7-43C3-AA01-F089CF02BBDB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EF8684C1-83B7-43C3-AA01-F089CF02BBDB}.Release|x86.ActiveCfg = Release|x86
 		{EF8684C1-83B7-43C3-AA01-F089CF02BBDB}.Release|x86.Build.0 = Release|x86
-		{76C5961A-21CC-4CB0-9840-1553F96DF77A}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{76C5961A-21CC-4CB0-9840-1553F96DF77A}.Debug|Any CPU.Build.0 = Debug|x86
-		{76C5961A-21CC-4CB0-9840-1553F96DF77A}.Debug|x86.ActiveCfg = Debug|x86
-		{76C5961A-21CC-4CB0-9840-1553F96DF77A}.Debug|x86.Build.0 = Debug|x86
-		{76C5961A-21CC-4CB0-9840-1553F96DF77A}.Release|Any CPU.ActiveCfg = Release|x86
-		{76C5961A-21CC-4CB0-9840-1553F96DF77A}.Release|x86.ActiveCfg = Release|x86
-		{76C5961A-21CC-4CB0-9840-1553F96DF77A}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This source code is not included and does not appear to be a dependency.